### PR TITLE
Prometheus metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 app.cfg
 __pycache__
 *.pyc
-
+.cache/
+metrics/
 #virtualenv
 bin/
 lib/
@@ -9,3 +10,4 @@ include/
 local/
 share/
 pip-selfcheck.json
+venv/

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ mongoengine==0.15.0
 mongomock==3.8.0
 pbr==3.1.1
 pluggy==0.6.0
+prometheus-client==0.1.0
 py==1.5.2
 pymongo==3.6.0
 pytest==3.3.1


### PR DESCRIPTION
Include metrics at /metrics. These include request counts and times. Note: request counts will be invalid for any of the web views, as they're cached by nginx. 