### PR TITLE
Link to device wiki instead of empty stats page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -25,7 +25,7 @@
 				<div class="leaderboard-header">Most active {{columns[0]}}</div>
 				{% for thing in stats[columns[0]] %}
 				<div class="leaderboard-row leaderboard-row-{{ 'a' if loop.index % 2 == 0 else 'b' }}">
-					<span class="leaderboard-left">{{ loop.index }}. <a href="/{{columns[0]}}/{{thing['_id']}}">{{ thing['_id'] }}</a></span>
+					<span class="leaderboard-left">{{ loop.index }}. <a href="https://wiki.lineageos.org/devices/{{thing['_id']}}">{{ thing['_id'] }}</a></span>
 					<span class="leaderboard-right">{{ thing['total'] }}</span>
 				</div>
 				{% endfor %}


### PR DESCRIPTION
Right now you click on the device symbol and land on an error page saying "Individual stats are not currently available". Until the individual device stats pages are available, I think that linking to that device's entry in the wiki would be helpful for the users (not everyone knows what bacon or serranoltexx is).